### PR TITLE
v1.5.6: Fix 'back to store' button to return to checkout page

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: your-company
 Tags: payments, checkout, woocommerce, visiofex, blocks, refunds
 Requires at least: 6.0
 Tested up to: 6.6
-Stable tag: 1.5.5
+Stable tag: 1.5.6
 License: MIT
 License URI: https://opensource.org/licenses/MIT
 
@@ -57,6 +57,12 @@ In wordpress (https://yoursite/wp-admin):
 - Save changes to enable the gateway
 
 == Changelog ==
+
+= 1.5.6 =
+* **CRITICAL FIX**: Fixed "back to store" button on VisioFex payment portal - now correctly returns to checkout page instead of order received page
+* **IMPROVED**: Separated returnURL (checkout page) from successURL (thank-you page) for proper user flow
+* **ENHANCED**: Better distinction between payment success redirect and store navigation
+* **RELIABILITY**: Customers can now properly return to checkout if they need to change payment details
 
 = 1.5.5 =
 * **CRITICAL FIX**: Removed duplicate WooCommerce Blocks registration that was causing WordPress notices and header warnings

--- a/visiofex-woocommerce-gateway.php
+++ b/visiofex-woocommerce-gateway.php
@@ -23,7 +23,7 @@ define('VXF_DEFAULT_STORE_DOMAIN', 'https://yourdomain.com');
  * Description: VisioFex/KonaCash hosted checkout for WooCommerce with refunds, Blocks support, and easy settings for keys, vendor id, and URLs.
  * Author:      NexaFlow Payments
  * Author URI:  https://nexaflowpayments.com
- * Version:     1.5.5
+ * Version:     1.5.6
  * Requires at least: 6.0
  * Requires PHP: 7.4
  * WC requires at least: 7.0
@@ -34,7 +34,7 @@ define('VXF_DEFAULT_STORE_DOMAIN', 'https://yourdomain.com');
 
 if ( ! defined( 'ABSPATH' ) ) { exit; }
 
-define( 'VXF_WC_VERSION', '1.5.5' );
+define( 'VXF_WC_VERSION', '1.5.6' );
 define( 'VXF_WC_PLUGIN_FILE', __FILE__ );
 define( 'VXF_WC_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
 define( 'VXF_WC_PLUGIN_URL', plugin_dir_url( __FILE__ ) );
@@ -717,8 +717,8 @@ add_action( 'plugins_loaded', function() {
             $this->log( 'Testing empty line items approach - Line items count: ' . count( $line_items ) . ', WC Total: ' . $order_total );
             
             // Canonical WooCommerce URLs using proper helper methods
-            $success = $this->get_return_url( $order );   // ✅ correct thank-you URL
-            $return  = $success;                           // ✅ send customers back to thank-you
+            $success = $this->get_return_url( $order );   // ✅ correct thank-you URL (after successful payment)
+            $return  = wc_get_checkout_url();              // ✅ checkout page (for "back to store" button)
             $cancel  = $order->get_cancel_order_url();     // ✅ proper cancel URL (with key & id)
 
             $this->log( 'Generated URLs - Success: ' . $success . ', Return: ' . $return . ', Cancel: ' . $cancel );


### PR DESCRIPTION
- Fixed returnURL to use checkout page (wc_get_checkout_url()) instead of order received page
- Separated returnURL (checkout) from successURL (thank-you page) for proper user flow
- Customers can now properly return to checkout from VisioFex payment portal
- Resolves issue where 'back to store' button was incorrectly sending users to order confirmation